### PR TITLE
🌎 Internationalization

### DIFF
--- a/src/glen.gleam
+++ b/src/glen.gleam
@@ -183,7 +183,7 @@ pub fn text_body(res: Response, text: String) -> Response {
 pub fn html_body(res: Response, html: String) -> Response {
   res
   |> set_body(Text(html))
-  |> set_header("content-type", "text/html")
+  |> set_header("content-type", "text/html; charset=utf-8")
 }
 
 /// Set the body of a response to JSON.


### PR DESCRIPTION
Hey!
When writing in a language other than English, having to add `charset=utf-8` on **every** call of `glen.html` can get pretty tiring. And since there's no real drawback in making UTF-8 the default, why not?